### PR TITLE
Ensure that the `#include` refers to the correct library specification in the example sketches

### DIFF
--- a/examples/BoardControl/BoardControl.ino
+++ b/examples/BoardControl/BoardControl.ino
@@ -5,7 +5,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void printDeviceInfo(NiclaSenseEnv& device) {
     Serial.print("🔌 Device (0x");

--- a/examples/ChangeI2CAddress/ChangeI2CAddress.ino
+++ b/examples/ChangeI2CAddress/ChangeI2CAddress.ino
@@ -4,7 +4,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void checkConnection(NiclaSenseEnv& device) {
     if (device.connected()) {

--- a/examples/FactoryReset/FactoryReset.ino
+++ b/examples/FactoryReset/FactoryReset.ino
@@ -4,7 +4,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void setup() {
     Serial.begin(115200);

--- a/examples/IndoorAirQuality/IndoorAirQuality.ino
+++ b/examples/IndoorAirQuality/IndoorAirQuality.ino
@@ -5,7 +5,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void displaySensorData(IndoorAirQualitySensor& sensor) {
     if (sensor.enabled()) {

--- a/examples/OrangeLED/OrangeLED.ino
+++ b/examples/OrangeLED/OrangeLED.ino
@@ -4,7 +4,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void pulseLED(OrangeLED& led) {
     // Fade in

--- a/examples/OutdoorAirQuality/OutdoorAirQuality.ino
+++ b/examples/OutdoorAirQuality/OutdoorAirQuality.ino
@@ -4,7 +4,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void displaySensorData(OutdoorAirQualitySensor& sensor) {
     if (sensor.enabled()) {

--- a/examples/RGBLED/RGBLED.ino
+++ b/examples/RGBLED/RGBLED.ino
@@ -4,7 +4,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"
+#include "Arduino_NiclaSenseEnv.h"
 
 void pulseLED(RGBLED &led) {
     Serial.println("🌈 RGB values: " + String(led.color().red) + ", " + String(led.color().green) + ", " + String(led.color().blue));

--- a/examples/TemperatureHumidity/TemperatureHumidity.ino
+++ b/examples/TemperatureHumidity/TemperatureHumidity.ino
@@ -4,7 +4,7 @@
  * Initial author: Sebastian Romero (s.romero@arduino.cc)
  */
 
-#include "NiclaSenseEnv.h"  // Include the NiclaSenseEnv library
+#include "Arduino_NiclaSenseEnv.h"  // Include the NiclaSenseEnv library
 
 void displaySensorData(TemperatureHumiditySensor& sensor) {
     if (sensor.enabled()) {


### PR DESCRIPTION
Corrects #include statements for all examples so that they compile. 

Closes https://github.com/arduino-libraries/Arduino_NiclaSenseEnv/issues/4