### PR TITLE
Don't upload multiple times to same artifact in sketch compilation workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,7 +23,6 @@ on:
 
 env:
   SKETCHES_REPORTS_PATH: sketches-reports
-  SKETCHES_REPORTS_ARTIFACT_NAME: sketches-reports
 
 jobs:
   build:
@@ -39,14 +38,23 @@ jobs:
       matrix:
         board:
           - fqbn: arduino:mbed_portenta:envie_m7
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7
           - fqbn: arduino:mbed_nano:nanorp2040connect
+            artifact-name-suffix: arduino-mbed__nano-nanorp2040connect
           - fqbn: arduino:mbed_nicla:nicla_vision
+            artifact-name-suffix: arduino-mbed_nicla-nicla_vision
           - fqbn: arduino:mbed_nicla:nicla_sense
+            artifact-name-suffix: arduino-mbed_nicla-nicla_sense
           - fqbn: arduino:mbed_nano:nano33ble
+            artifact-name-suffix: arduino-mbed_nano-nano33ble
           - fqbn: arduino:renesas_portenta:portenta_c33
+            artifact-name-suffix: arduino-renesas_portenta-portenta_c33
           - fqbn: arduino:renesas_uno:unor4wifi
+            artifact-name-suffix: arduino-renesas_uno-unor4wifi
           - fqbn: arduino:samd:mkrwifi1010
+            artifact-name-suffix: arduino-samd-mkrwifi1010
           - fqbn: arduino:esp32:nano_nora
+            artifact-name-suffix: arduino-esp32-nano_nora
 
     steps:
       - name: Checkout repository
@@ -66,7 +74,7 @@ jobs:
         with:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}
 
   report-size-deltas:
     needs: build
@@ -82,7 +90,6 @@ jobs:
         continue-on-error: true # If compilation failed for all boards then there are no artifacts
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
           path: ${{ env.SKETCHES_REPORTS_PATH }}
 
       - name: Comment size deltas report to PR


### PR DESCRIPTION
The "Compile Examples" GitHub Actions workflow is configured to compile the example sketches for each of the supported boards. This is done by using a [job matrix](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) in the GitHub Actions workflow to generate a parallel job for each board.

A GitHub Actions [workflow artifact](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) is used to transfer the sketches report files generated by the [**arduino/compile-sketches**](https://github.com/arduino/compile-sketches) action between the compilation job and the "report-size-deltas" job that uses the [**arduino/report-size-deltas**](https://github.com/arduino/report-size-deltas) action to publish the data. The [**actions/upload-artifact**](https://github.com/actions/upload-artifact) GitHub Actions action action is used to upload the sketches report files to the workflow artifact.

Previously, the sketches reports from all the boards were uploaded to a single artifact. However, [support for uploading multiple times to a single artifact was dropped in version 4.0.0 of the **actions/upload-artifact** action](https://github.com/actions/upload-artifact#breaking-changes). Previously, the workflow did that, and so when the action was bumped (https://github.com/arduino-libraries/Arduino_NiclaSenseEnv/commit/5423dc9ac5da8edf84c53826009439d0a3e7f3e8), it caused the workflow runs to fail spuriously:

https://github.com/arduino-libraries/Arduino_NiclaSenseEnv/actions/runs/13783108129

```text
Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

So it is now necessary for each of the compilation jobs to use a separate artifact.

These multiple artifacts are downloaded in aggregate in the "report-size-deltas" job by the "actions/download-artifact" action, which downloads all artifacts by default.